### PR TITLE
Add github action to publish to pypi - 2

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -22,19 +22,19 @@ jobs:
         run: |
           pip install dist/*.whl
           python -c "import oci_mlflow;"
-      # To run publish to test PyPI, secret with token needs to be added to oracle/oci-mlflow project.
-      # This one - GH_OCI_MLFLOW_TESTPYPI_TOKEN - removed from project secrets after initial test.
-      - name: Publish distribution 📦 to Test PyPI
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.GH_OCI_MLFLOW_TESTPYPI_TOKEN }}
-        run: |
-          pip install twine
-          twine upload -r testpypi dist/* -u $TWINE_USERNAME -p $TWINE_PASSWORD
-#      - name: Publish distribution 📦 to PyPI
+#      # To run publish to test PyPI, secret with token needs to be added to oracle/oci-mlflow project.
+#      # This one - GH_OCI_MLFLOW_TESTPYPI_TOKEN - removed from project secrets after initial test.
+#      - name: Publish distribution 📦 to Test PyPI
 #        env:
 #          TWINE_USERNAME: __token__
-#          TWINE_PASSWORD: ${{ secrets.GH_OCI_MLFLOW_PYPI_TOKEN }}
+#          TWINE_PASSWORD: ${{ secrets.GH_OCI_MLFLOW_TESTPYPI_TOKEN }}
 #        run: |
 #          pip install twine
-#          twine upload dist/* -u $TWINE_USERNAME -p $TWINE_PASSWORD
+#          twine upload -r testpypi dist/* -u $TWINE_USERNAME -p $TWINE_PASSWORD
+      - name: Publish distribution 📦 to PyPI
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.GH_OCI_MLFLOW_PYPI_TOKEN }}
+        run: |
+          pip install twine
+          twine upload dist/* -u $TWINE_USERNAME -p $TWINE_PASSWORD


### PR DESCRIPTION
### Description

After successful publish mlflow to Test PyPI with CG Actions, comment publish to Test PyPI step, un-comment publish to PyPI step in publish-to-pypi.yml

### Validation

1. Action completed successfully - https://github.com/oracle/oci-mlflow/actions/runs/5158950279/jobs/9293246040
2. Test PiPI got new version of oci-mlflow, as expected - https://test.pypi.org/project/oci-mlflow/#history