### PR TITLE
Fixes the "launch_mlflow.sh" file. The copyright information was added in a wrong place

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ CONTAINERDIR:=container-image
 RND:=1
 
 clean:
-	@rm -rf dist build oci_mlflow.egg-info
+	@rm -rf dist build oci_mlflow.egg-info $(CONTAINERDIR)/run/*.whl
 	@find ./ -name '*.pyc' -exec rm -f {} \;
 	@find ./ -name 'Thumbs.db' -exec rm -f {} \;
 	@find ./ -name '*~' -exec rm -f {} \;
@@ -16,16 +16,15 @@ clean:
 dist: clean
 	@python setup.py bdist_wheel
 
-wheel: dist tmp-copy-whl
-
 build-image:
 	docker build --network host --build-arg RND=$(RND) -t $(IMAGE_NAME):$(TAG) -f container-image/Dockerfile .
+	$(MAKE) clean
 
 launch: build-image
 	@docker run --rm -it --net host -v ~/.oci:/root/.oci --env-file .env --name oci-mlflow $(IMAGE_NAME):$(TAG)
 
-launch-shell:
+launch-shell: build-image
 	@docker run --rm -it --net host -v ~/.oci:/root/.oci  --env-file .env --entrypoint bash --name oci-mlflow-shell $(IMAGE_NAME):$(TAG)
 
-launch-shell-remote:
-	@docker run --rm -it --net host --env-file .env --entrypoint bash --name oci-mlflow-shell $(IMAGE_NAME):$(TAG)
+wheel: dist
+	@cp dist/*.whl container-image/run/

--- a/README-development.md
+++ b/README-development.md
@@ -7,6 +7,22 @@ The target audience for this README is developers wanting to contribute to `OCI 
 python3 -m pip install -r dev-requirements.txt
 ```
 
+# Generating the wheel
+The OCI MLflow plugins are packaged as a wheel. To generate the wheel, you can run:
+
+```
+make dist
+```
+
+Alternatively you can run -
+
+```
+python setup.py bdist_wheel
+```
+
+This wheel can then be installed using pip.
+
+
 ## Setting Up Tracking Server
 
 Create a file called `.env` in the root folder of the project with following contents -
@@ -25,12 +41,14 @@ BACKEND_PROVIDER=sqllite
 # ------MySQL-----------------------
 # BACKEND_PROVIDER=mysql
 
-# The database credentials can be stored in the Vault service, or they can be provided in the config. See more details how to save the credentials to the Vault - https://accelerated-data-science.readthedocs.io/en/latest/user_guide/secrets/mysql.html
+# The database credentials can be stored in the Vault service, or they can be provided in the config.
+# See more details how to save the credentials to the Vault -
+# https://accelerated-data-science.readthedocs.io/en/latest/user_guide/secrets/mysql.html
 
 # DB_SECRET_OCID=ocid1.vaultsecret.oc1.iad..<unique_ID>
-# DBHOST=<host ip>
-# DBUSERNAME=<db username>
-# DBPASSWORD=<password>
+
+# ----OR------------------------------
+# MLFLOW_BACKEND_STORE_URI=mysql+mysqlconnector://{username}:{password}@{host}:{db_port}/{db_name}
 # ------------------------------------
 
 MLFLOW_SERVE_ARTIFACTS=1
@@ -44,27 +62,55 @@ MLFLOW_HOST=0.0.0.0
 To build an `oci-mlflow` container image run -
 
 ```
-make build-image
+make clean build-image
+```
+
+Alternatively you can run -
+```
+docker build --network host --build-arg RND=1 -t oci-mlflow:latest -f container-image/Dockerfile .
 ```
 
 To build and launch tracking server run -
 
 ```
-make launch
+make clean launch
+```
+
+Alternatively you can run -
+```
+docker build --network host --build-arg RND=1 -t oci-mlflow:latest -f container-image/Dockerfile .
+docker run --rm -it --net host -v ~/.oci:/root/.oci --env-file .env --name oci-mlflow:latest
 ```
 
 To build `oci-mlflow` wheel file and then rebuild and launch the container image, run -
 
 ```
-make wheel launch
+make clean wheel launch
+```
+
+Alternatively you can run -
+
+```
+python setup.py bdist_wheel
+cp dist/*.whl container-image/run/
+docker build --network host --build-arg RND=1 -t oci-mlflow:latest -f container-image/Dockerfile .
+docker run --rm -it --net host -v ~/.oci:/root/.oci --env-file .env --name oci-mlflow oci-mlflow:latest
 ```
 
 To build and start a shell prompt within `oci-mlflow` container image, run -
 
 ```
-make launch-shell
+make clean wheel launch-shell
 ```
 
+Alternatively you can run -
+
+```
+python setup.py bdist_wheel
+cp dist/*.whl container-image/run/
+docker build --network host --build-arg RND=1 -t oci-mlflow:latest -f container-image/Dockerfile .
+docker run --rm -it --net host -v ~/.oci:/root/.oci --env-file .env --entrypoint bash --name oci-mlflow-shell oci-mlflow:latest
+```
 
 # Running Tests
 The SDK uses pytest as its test framework. To run tests use:
@@ -81,12 +127,3 @@ python3 -m pip install -r dev-requirements.txt
 cd docs
 make html
 ```
-
-# Generating the wheel
-The OCI MLflow plugins are packaged as a wheel. To generate the wheel, you can run:
-
-```
-make build
-```
-
-This wheel can then be installed using pip.

--- a/container-image/Dockerfile
+++ b/container-image/Dockerfile
@@ -24,13 +24,17 @@ ENV PATH="/miniconda/envs/${CONDA_ENV_NAME}}/bin:$PATH"
 RUN conda init bash && source ~/.bashrc && conda activate ${CONDA_ENV_NAME}
 
 RUN mkdir ${MLFLOW_DIR}
-COPY ${CONTAINER_ARTIFACT_DIR}/run.py ${MLFLOW_DIR}/run.py
-COPY ${CONTAINER_ARTIFACT_DIR}/launch_mlflow.sh ${MLFLOW_DIR}/launch_mlflow.sh
+ADD ${CONTAINER_ARTIFACT_DIR}/run ${MLFLOW_DIR}/
 RUN chmod a+x ${MLFLOW_DIR}/launch_mlflow.sh
 
 ENV MLFLOW_DIR=${MLFLOW_DIR}
 
 EXPOSE 5000
+
+RUN if [ -f ${MLFLOW_DIR}/oci_mlflow*.whl ]; then \
+        local_whl=$(find ${MLFLOW_DIR} -name "*.whl" -exec basename {} \; | head -n 1 ); \
+        source ~/.bashrc && conda activate ${CONDA_ENV_NAME} && pip install ${MLFLOW_DIR}/$local_whl; \
+    fi
 
 RUN echo "conda activate oci-mlflow">>/root/.bashrc
 SHELL ["/bin/bash", "--login", "-c"]

--- a/container-image/Dockerfile
+++ b/container-image/Dockerfile
@@ -24,7 +24,7 @@ ENV PATH="/miniconda/envs/${CONDA_ENV_NAME}}/bin:$PATH"
 RUN conda init bash && source ~/.bashrc && conda activate ${CONDA_ENV_NAME}
 
 RUN mkdir ${MLFLOW_DIR}
-ADD ${CONTAINER_ARTIFACT_DIR}/run ${MLFLOW_DIR}/
+COPY ${CONTAINER_ARTIFACT_DIR}/run/* ${MLFLOW_DIR}/
 RUN chmod a+x ${MLFLOW_DIR}/launch_mlflow.sh
 
 ENV MLFLOW_DIR=${MLFLOW_DIR}

--- a/container-image/run/launch_mlflow.sh
+++ b/container-image/run/launch_mlflow.sh
@@ -1,8 +1,8 @@
+#!/bin/bash --login
 # Copyright (c) 2023 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at
 # https://oss.oracle.com/licenses/upl/
 
-#!/bin/bash --login
 set -m -e -o pipefail
 
 conda activate oci-mlflow

--- a/container-image/run/run.py
+++ b/container-image/run/run.py
@@ -126,6 +126,10 @@ def launch_mlflow():
     # It is better to pass extra args through environment variables.
     # More info - https://mlflow.org/docs/latest/cli.html#mlflow-server
     cmd_split = shlex.split(mlflow_cmd_option)
+
+    print("*"*50)
+    print([MLFLOW_LAUNCH_SCRIPT] + cmd_split)
+    print("*"*50)
     subprocess.run(
         [MLFLOW_LAUNCH_SCRIPT] + cmd_split,  # capture_output=True
     )

--- a/container-image/run/run.py
+++ b/container-image/run/run.py
@@ -126,10 +126,6 @@ def launch_mlflow():
     # It is better to pass extra args through environment variables.
     # More info - https://mlflow.org/docs/latest/cli.html#mlflow-server
     cmd_split = shlex.split(mlflow_cmd_option)
-
-    print("*"*50)
-    print([MLFLOW_LAUNCH_SCRIPT] + cmd_split)
-    print("*"*50)
     subprocess.run(
         [MLFLOW_LAUNCH_SCRIPT] + cmd_split,  # capture_output=True
     )


### PR DESCRIPTION
## Description
* Updated "README-development.md"
* Fixed "launch_mlflow.sh" file. The copyright information was added in a wrong place
* Updated "Dockerfile". Added possibility to run tracking server with local version of "oci-mlflow"
* Updated "Makefile"

## Local Tests

### Build image without local `oci-mlflow.whl`
![image](https://github.com/oracle/oci-mlflow/assets/5256765/0e30b019-22cb-424a-80cd-c2a082c3e42e)
![image](https://github.com/oracle/oci-mlflow/assets/5256765/5639ebfe-9ec4-4aa1-b39c-9c6e8dd2d097)

### Build image with  local `oci-mlflow.whl`
![image](https://github.com/oracle/oci-mlflow/assets/5256765/46a0af58-ccc7-43c3-8fba-468e3da412d7)
![image](https://github.com/oracle/oci-mlflow/assets/5256765/aa2efb7e-ae99-4087-bb7e-4f641ec69c2f)
![image](https://github.com/oracle/oci-mlflow/assets/5256765/73beb743-4b22-4383-ad80-3514f5fff8ff)
![image](https://github.com/oracle/oci-mlflow/assets/5256765/c0b14ed8-f38c-4125-960f-93277efd1199)
<img width="905" alt="image" src="https://github.com/oracle/oci-mlflow/assets/5256765/5253d683-8ad9-4555-a7fc-adf5bad1988e">
