### PR TITLE
Add .readthedocs.yaml configuration file for RTD

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,19 @@
+# Read the Docs configuration file
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.9"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+   configuration: docs/source/conf.py
+
+# Optionally declare the Python requirements required to build your docs
+python:
+   install:
+   - requirements: docs/requirements.txt


### PR DESCRIPTION
### Description

To setup automated rules to trigger readthedocs (RTD) build, when new version release, special configuration file for RTD needs to be added.
Jira: https://jira.oci.oraclecorp.com/browse/ODSC-42785