### PR TITLE
Add workflow to trigger build/publish docs

### DIFF
--- a/.github/workflows/publish-to-readthedocs.yml
+++ b/.github/workflows/publish-to-readthedocs.yml
@@ -1,0 +1,31 @@
+name: "Publish Docs"
+
+on:
+  # Auto-trigger this workflow on tag creation
+  push:
+    tags:
+      - 'v*.*.*'
+
+env:
+  RTDS_MLFLOW_PROJECT: https://readthedocs.org/api/v3/projects/accelerated-data-science
+  RTDS_MLFLOW_TOKEN: ${{ secrets.RTDS_MLFLOW_TOKEN }}
+
+jobs:
+  build-n-publish:
+    name: Build and publish Docs 📖 to Readthedocs
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: When tag 🏷️ pushed - Trigger Readthedocs build
+        if: github.event_name == 'push' && startsWith(github.ref_name, 'v')
+        run: |
+          # trigger build/publish of latest version
+          curl \
+            -X POST \
+            -H "Authorization: Token $RTDS_MLFLOW_TOKEN" $RTDS_MLFLOW_PROJECT/versions/latest/builds/
+          # add 15 minutes wait time for readthedocs see freshly created tag
+          sleep 15m
+          # trigger build/publish of v*.*.* version
+          curl \
+            -X POST \
+            -H "Authorization: Token $RTDS_MLFLOW_TOKEN" $RTDS_MLFLOW_PROJECT/versions/${{ github.ref_name }}/builds/


### PR DESCRIPTION
### Description

Added actions (workflow), which will send post request to trigger building and publishing docs, when new release created (new tag starting 'v' created).
Jira: https://jira.oci.oraclecorp.com/browse/ODSC-42785

- added publish-to-readthedocs.yml