### PR TITLE
Add coverage report message to PRs

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,28 @@
+[run]
+omit =
+    **/*.jinja2
+    **/__init__.py
+    container-image/*
+    docs/*
+    tests/*
+
+[report]
+exclude_lines =
+    pragma: no cover
+    def __repr__
+    if __name__ == .__main__.:
+    @(abc\.)?abstractmethod
+    raise AssertionError
+    raise NotImplementedError
+omit =
+    **/*.jinja2
+    **/__init__.py
+    container-image/*
+    docs/*
+    tests/*
+show_missing = true
+skip_empty = true
+precision = 2
+
+[html]
+directory = htmlcov

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -34,6 +34,10 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.8", "3.9", "3.10"]
+        include:
+          - python-version: "3.9"
+            cov-reports: --cov=ads --cov-report=xml --cov-report=html
+
 
     steps:
       - uses: actions/checkout@v3
@@ -71,13 +75,50 @@ jobs:
           cat $HOME_RUNNER_DIR/.oci/config
 
       - name: "Run tests"
-        timeout-minutes: 15
+        timeout-minutes: 5
         shell: bash
-        env:
-          NoDependency: True
         run: |
           set -x # print commands that are executed
           $CONDA/bin/conda init
           source /home/runner/.bashrc
           pip install -r test-requirements.txt
-          python -m pytest -v -p no:warnings --durations=5 tests
+          python -m pytest ${{ matrix.cov-reports }} tests
+
+      - name: "Save coverage files"
+        uses: actions/upload-artifact@v3
+        if: ${{ matrix.cov-reports }}
+        with:
+          name: cov-reports-${{ matrix.name }}
+          path: |
+            htmlcov/
+            .coverage
+            coverage.xml
+
+      - name: "Add comment with coverage info to PR"
+        if: ${{ success() }} && ${{ github.event.issue.pull_request }}
+        run: |
+          set -x # print commands that are executed
+          
+          # Prepare default cov body text 
+          COV_BODY_INTRO="📌 Overall coverage:\n\n"
+          echo COV_BODY="$COV_BODY_INTRO No success to gather report. 😿" >> $GITHUB_ENV
+          
+          # Calculate overall coverage and update body message
+          COV=$(grep -E 'pc_cov' htmlcov/index.html | cut -d'>' -f 2 | cut -d'%' -f 1)
+            if [[ ! -z $COV ]]; then 
+              if [[ $COV -lt 50 ]]; then COLOR=red; elif [[ $COV -lt 80 ]]; then COLOR=yellow; else COLOR=green; fi
+              echo COV_BODY="$COV_BODY_INTRO ![Coverage-$COV%](https://img.shields.io/badge/coverage-$COV%25-$COLOR)" >> $GITHUB_ENV
+            fi
+
+      - name: "Add comment with cov diff to PR"
+        uses: actions/github-script@v6
+        if: ${{ success() }} && ${{ github.event.issue.pull_request }}
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '${{ env.COV_BODY }}'
+            })

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,5 @@
 [pytest]
+addopts = -v -p no:warnings --durations=5
 testpaths = tests
 pythonpath = . oci_mlflow
 env =


### PR DESCRIPTION
### Description

Added coverage reports (html, xml) as artifacts saved after test run on python 3.9. Added message to open PR with one number summary of overall coverage for the project.

Jira: https://jira.oci.oraclecorp.com/browse/ODSC-42787

- added .coveragerc to setup coverage reporting
- added addopts to pytest.ini
- added coverage report steps into run-tests.yml