### PR TITLE
GitHub Actions: Transitioning from Node 16 to Node 20

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.x"
       - name: Build distribution 📦

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -40,17 +40,17 @@ jobs:
             cov-reports: --cov=oci_mlflow --cov-report=xml --cov-report=html
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       # Caching python libraries installed with pip
       # https://github.com/actions/cache/blob/main/examples.md#python---pip
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/test-requirements.txt') }}
           restore-keys: |
             ${{ runner.os }}-pip-
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -102,7 +102,7 @@ jobs:
             fi
 
       - name: "Add comment with coverage info to PR"
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         if: ${{ success() }} && ${{ github.event.issue.pull_request }}
         with:
           github-token: ${{ github.token }}
@@ -115,7 +115,7 @@ jobs:
             })
 
       - name: "Save coverage files"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ matrix.cov-reports }}
         with:
           name: cov-reports


### PR DESCRIPTION
### Description

https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20
Jira: https://jira.oci.oraclecorp.com/browse/ODSC-52248

### What was done

- updated versions in used actions for checkout, setup-python, cache, github-script, upload-artifact