### PR TITLE
Added ruff to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,49 +1,55 @@
 repos:
+  # ruff
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.4.9
+    hooks:
+    - id: ruff
+      types_or: [ python, pyi, jupyter ]
+      args: [ --fix ]
+      files: ^ads
+      exclude: ^docs/
+    - id: ruff-format
+      types_or: [ python, pyi, jupyter ]
+      exclude: ^docs/
 # Standard hooks
--   repo: https://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:
-    -   id: check-ast
-        exclude: ^docs/
-    -   id: check-docstring-first
-        exclude: ^(docs/|tests/)
-    -   id: check-json
-    -   id: check-merge-conflict
-    -   id: check-yaml
-        args: ['--allow-multiple-documents']
-    -   id: detect-private-key
-    -   id: end-of-file-fixer
-    -   id: pretty-format-json
-        args: ['--autofix']
-    -   id: trailing-whitespace
-        args: [ --markdown-linebreak-ext=md ]
-        exclude: ^docs/
-# Black, the code formatter, natively supports pre-commit
--   repo: https://github.com/psf/black
-    rev: 23.3.0
-    hooks:
-    -   id: black
-        exclude: ^docs/
+    - id: check-ast
+      exclude: ^docs/
+    - id: check-docstring-first
+      exclude: ^(docs/|tests/)
+    - id: check-json
+    - id: check-merge-conflict
+    - id: check-yaml
+      args: ['--allow-multiple-documents']
+    - id: detect-private-key
+    - id: end-of-file-fixer
+    - id: pretty-format-json
+      args: ['--autofix']
+    - id: trailing-whitespace
+      args: [ --markdown-linebreak-ext=md ]
+      exclude: ^docs/
 # Regex based rst files common mistakes detector
--   repo: https://github.com/pre-commit/pygrep-hooks
+  - repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.10.0
     hooks:
-    -   id: rst-backticks
-        files: ^docs/
-    -   id: rst-inline-touching-normal
-        files: ^docs/
+    - id: rst-backticks
+      files: ^docs/
+    - id: rst-inline-touching-normal
+      files: ^docs/
 # Hardcoded secrets and ocids detector
--   repo: https://github.com/gitleaks/gitleaks
+  - repo: https://github.com/gitleaks/gitleaks
     rev: v8.17.0
     hooks:
-    -   id: gitleaks
+    - id: gitleaks
 # Oracle copyright checker
--   repo: https://github.com/oracle-samples/oci-data-science-ai-samples/
+  - repo: https://github.com/oracle-samples/oci-data-science-ai-samples/
     rev: cbe0136
     hooks:
-    -   id: check-copyright
-        name: check-copyright
-        entry: .pre-commit-scripts/check-copyright.py
-        language: script
-        types_or: ['python', 'shell', 'bash']
-        exclude: ^docs/
+    - id: check-copyright
+      name: check-copyright
+      entry: .pre-commit-scripts/check-copyright.py
+      language: script
+      types_or: ['python', 'shell', 'bash']
+      exclude: ^docs/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,3 +70,45 @@ oci-datascience = "oci_mlflow.deployment"
 
 [project.entry-points."mlflow.request_auth_provider"]
 oci-datascience = "oci_mlflow.auth_plugin:OCIMLFlowAuthRequestProvider"
+
+# Configuring Ruff (https://docs.astral.sh/ruff/configuration/)
+[tool.ruff]
+fix = true
+
+[tool.ruff.lint]
+exclude = ["*.yaml", "*jinja2"]
+# rules - https://docs.astral.sh/ruff/rules/
+extend-ignore = ["E402", "N806", "N803"]
+ignore = [
+  "S101",    # use of assert
+  "B008",    # function call in argument defaults
+  "B017",    # pytest.raises considered evil
+  "B023",    # function definition in loop (TODO: un-ignore this)
+  "B028",    # explicit stacklevel for warnings
+  "C901",    # function is too complex (TODO: un-ignore this)
+  "E501",    # from scripts/lint_backend.sh
+  "PLR091",  # complexity rules
+  "PLR2004", # magic numbers
+  "PLW2901", # `for` loop variable overwritten by assignment target
+  "SIM105",  # contextlib.suppress (has a performance cost)
+  "SIM117",  # multiple nested with blocks (doesn't look good with gr.Row etc)
+  "UP006",   # use `list` instead of `List` for type annotations (fails for 3.8)
+  "UP007",   # use X | Y for type annotations (TODO: can be enabled once Pydantic plays nice with them)
+]
+extend-select = [
+  "ARG",
+  "B",
+  "C",
+  "E",
+  "F",
+  "I",
+  "N",
+  "PL",
+  "S101",
+  "SIM",
+  "UP",
+  "W",
+]
+
+[tool.ruff.lint.per-file-ignores]
+"__init__.py" = ["F401"]

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,3 +4,4 @@ mock
 pip
 pytest
 pytest-codecov
+ruff


### PR DESCRIPTION
### Description
Ruff can be used to replace Flake8 (plus dozens of plugins), Black, isort, pydocstyle, and more, all while executing tens or hundreds of times faster than any individual tool.

Added ruff to run mainly default settings with little extra and exclude. While developing our code we will add/exclude more. Please check on rules and suggest what can be added to default (section 'select' in pyproject.toml) and what can be excluded (section 'ignore' in pyproject.toml)- https://docs.astral.sh/ruff/rules/.

### What was done
- added repo to .pre-commit-config.yaml
- added rules to pyproject.toml
- removed black, because ruff has drop-in parity with it