### PR TITLE
fix incorrect type in oci_object_storage.py

### DIFF
--- a/oci_mlflow/oci_object_storage.py
+++ b/oci_mlflow/oci_object_storage.py
@@ -172,7 +172,7 @@ class OCIObjectStorageArtifactRepository(ArtifactRepository):
             full_path = remote_file_path
         fs: OCIFileSystem = self.get_fs()
         logger.info(f"{full_path}, {remote_file_path}")
-        fs.download(full_path, local_path)
+        fs.download(full_path, str(local_path))
 
     def log_artifact(self, local_file: str, artifact_path: str = None):
         """


### PR DESCRIPTION
Without this change MLFlow fails to download traces.

It shows 404 error by default. After some debugging I found that there is an error:

```
mlflow-tracking-97cf9d454-jmqtq mlflow   File "/miniconda/envs/oci-mlflow/lib/python3.9/site-packages/mlflow/store/artifact/artifact_repo.py", line 336, in download_trace_data
mlflow-tracking-97cf9d454-jmqtq mlflow     self._download_file(TRACE_DATA_FILE_NAME, temp_file)
mlflow-tracking-97cf9d454-jmqtq mlflow   File "/miniconda/envs/oci-mlflow/lib/python3.9/site-packages/oci_mlflow/oci_object_storage.py", line 107, in _download_file
mlflow-tracking-97cf9d454-jmqtq mlflow     fs.download(full_path, local_path)
mlflow-tracking-97cf9d454-jmqtq mlflow   File "/miniconda/envs/oci-mlflow/lib/python3.9/site-packages/fsspec/spec.py", line 1767, in download
mlflow-tracking-97cf9d454-jmqtq mlflow     return self.get(rpath, lpath, recursive=recursive, **kwargs)
mlflow-tracking-97cf9d454-jmqtq mlflow   File "/miniconda/envs/oci-mlflow/lib/python3.9/site-packages/fsspec/spec.py", line 966, in get
mlflow-tracking-97cf9d454-jmqtq mlflow     lpaths = other_paths(
mlflow-tracking-97cf9d454-jmqtq mlflow   File "/miniconda/envs/oci-mlflow/lib/python3.9/site-packages/fsspec/utils.py", line 423, in other_paths
mlflow-tracking-97cf9d454-jmqtq mlflow     assert len(paths) == len(path2)
mlflow-tracking-97cf9d454-jmqtq mlflow TypeError: object of type 'PosixPath' has no len()
```

If I switch type to string, then fsspec works as expected.